### PR TITLE
Mudança no cálculo mod11

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Função | Definição
 
 ---------------------------------------------------------
 ### 3. Exemplos de uso
-A princípio, a função `validarBoleto(codigo: string)` é a única que poderia ser utilizada para validar e trazer informações de um código de barras/linha digitável, portanto mostrarei apenas este exemplo. As demais funções estão documentadas acima e são autoexplicativas.
+A princípio, a função `validarBoleto(codigo: string, tipoCodigo: string)` é a única que poderia ser utilizada para validar e trazer informações de um código de barras/linha digitável, portanto mostrarei apenas este exemplo. As demais funções estão documentadas acima e são autoexplicativas.
 
 Exemplo #1: 
 ```javascript
-validarBoleto('23790448095616862379336011058009740430000124020');
+validarBoleto('23790448095616862379336011058009740430000124020', 'LINHA_DIGITAVEL');
 ```
 Retorno #1: 
 ```json
@@ -58,7 +58,7 @@ Retorno #1:
 ```
 Exemplo #2: 
 ```javascript
-validarBoleto('34196790600001000002220000005566385101214000');
+validarBoleto('34196790600001000002220000005566385101214000', 'CODIGO_DE_BARRAS);
 ```
 Retorno #2: 
 ```json

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -463,10 +463,22 @@ exports.validarCodigoComDV = (codigo) => {
                 bloco3 = codigo.substr(24, 11) + this.calculaMod10(codigo.substr(24, 11));
                 bloco4 = codigo.substr(36, 11) + this.calculaMod10(codigo.substr(36, 11));
             } else if (identificacaoValorRealOuReferencia.mod == 11) {
-                bloco1 = codigo.substr(0, 11) + this.calculaMod11(codigo.substr(0, 11));
-                bloco2 = codigo.substr(12, 11) + this.calculaMod11(codigo.substr(12, 11));
-                bloco3 = codigo.substr(24, 11) + this.calculaMod11(codigo.substr(24, 11));
-                bloco4 = codigo.substr(36, 11) + this.calculaMod11(codigo.substr(36, 11));
+                bloco1 = codigo.substr(0, 11);
+                bloco2 = codigo.substr(12, 11);
+                bloco3 = codigo.substr(24, 11);
+                bloco4 = codigo.substr(36, 11);
+
+                dv1 = parseInt(codigo.substr(11, 1));
+                dv2 = parseInt(codigo.substr(23, 1));
+                dv3 = parseInt(codigo.substr(35, 1));
+                dv4 = parseInt(codigo.substr(47, 1));
+                
+                valid = (this.calculaMod11(bloco1) == dv1 &&
+                        this.calculaMod11(bloco2) == dv2 &&
+                        this.calculaMod11(bloco3) == dv3 &&
+                        this.calculaMod11(bloco4) == dv4)
+
+                return valid;
             }
 
             resultado = bloco1 + bloco2 + bloco3 + bloco4;
@@ -709,29 +721,24 @@ exports.calculaMod10 = (numero) => {
  * @return {string} soma
  */
 exports.calculaMod11 = (numero) => {
+    // from: http://www.cjdinfo.com.br/publicacao-calculo-digito-verificador
     numero = numero.replace(/\D/g, '');
 
+    let sequencia = [4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
     let soma = 0;
-    let peso = 2;
-    const base = 9;
-    const contador = numero.length - 1;
-    for (let i = contador; i >= 0; i--) {
-        soma = soma + (parseInt(numero.substring(i, i + 1)) * peso);
-        if (peso < base) {
-            peso++;
-        } else {
-            peso = 2;
-        }
-    }
-    let digito = 11 - (soma % 11);
-    if (digito > 9) {
-        digito = 0;
+    let resto = 0;
+
+    for (let i = 0; i < 11; i++) {
+        let valor = parseInt(numero.substr(i, 1));
+        soma += valor * sequencia[i];
     }
 
-    // Se for igual a 0, 10 ou 11, o dígito será 1 
-    if (digito === 0 || digito === 10 || digito === 11) {
-        digito = 1;
-    }
+    soma *= 10;
+    console.log(soma);
+
+    resto = soma % 11;
+    let digito = resto;
+    if (resto == 10) digito = 0;
 
     return digito;
 }

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -734,7 +734,6 @@ exports.calculaMod11 = (numero) => {
     }
 
     soma *= 10;
-    console.log(soma);
 
     resto = soma % 11;
     let digito = resto;

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -488,8 +488,6 @@ exports.validarCodigoComDV = (codigo, tipoCodigo) => {
         if (tipoBoleto == 'BANCO') {
             const DV = this.calculaDVCodBarras(codigo, 4, 11);
             resultado = codigo.substr(0, 4) + DV + codigo.substr(5);
-            console.log(DV)
-            console.log(codigo)
         } else {
             const identificacaoValorRealOuReferencia = this.identificarReferencia(codigo);
 

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -417,7 +417,7 @@ exports.calculaDVCodBarras = (codigo, posicaoCodigo, mod) => {
     if (mod === 10) {
         return this.calculaMod10(codigo);
     } else if (mod === 11) {
-        return this.calculaMod11(codigo);
+        return this.calculaMod11SemMultiplicacao10(codigo);
     }
 }
 
@@ -740,6 +740,33 @@ exports.calculaMod11 = (numero) => {
     if (resto == 10) digito = 0;
 
     return digito;
+}
+
+/** 
+ * Calcula o dígito verificador de uma numeração a partir do módulo 11
+ * 
+ * -------------
+ * 
+ * @param {string} numero Numeração
+ * 
+ * -------------
+ * 
+ * @return {string} soma
+ */
+exports.calculaMod11SemMultiplicacao10 = (numero) => {
+    let sequencia = [2, 3, 4, 5, 6, 7, 8, 9];
+    let digit = 0;
+    let j = 0;
+    for (var i = x.length - 1; i >= 0; i--) {
+        if (i != 4) {
+            let mult = sequencia[j];
+            j++;
+            j %= sequencia.length;
+            digit += mult * parseInt(x.charAt(i));
+        }
+    }
+
+    return digit % 11;
 }
 
 /** 

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -616,9 +616,11 @@ exports.geraCodBarras = (codigo) => {
  * __Y__ | **35 a 35**  | `Dígito verificador do Bloco 3`
  * __Z__ | **47 a 47**  | `Dígito verificador do Bloco 4`
  */
-exports.validarBoleto = (codigo, tipoCodigo) => {
+exports.validarBoleto = (codigo) => {
     let retorno = {};
     codigo = codigo.replace(/[^0-9]/g, '');
+
+    let tipoCodigo = this.identificarTipoCodigo(codigo);
 
     /** 
      * Boletos de cartão de crédito geralmente possuem 46 dígitos. É necessário adicionar mais um zero no final, para formar 47 caracteres 

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -432,9 +432,8 @@ exports.calculaDVCodBarras = (codigo, posicaoCodigo, mod) => {
  * 
  * @return {boolean} true = boleto válido / false = boleto inválido
  */
-exports.validarCodigoComDV = (codigo) => {
+exports.validarCodigoComDV = (codigo, tipoCodigo) => {
     codigo = codigo.replace(/[^0-9]/g, '');
-    let tipoCodigo = this.identificarTipoCodigo(codigo);
     let tipoBoleto;
 
     let resultado;
@@ -489,6 +488,8 @@ exports.validarCodigoComDV = (codigo) => {
         if (tipoBoleto == 'BANCO') {
             const DV = this.calculaDVCodBarras(codigo, 4, 11);
             resultado = codigo.substr(0, 4) + DV + codigo.substr(5);
+            console.log(DV)
+            console.log(codigo)
         } else {
             const identificacaoValorRealOuReferencia = this.identificarReferencia(codigo);
 
@@ -497,7 +498,6 @@ exports.validarCodigoComDV = (codigo) => {
             resultado = resultado.join('');
 
             const DV = this.calculaDVCodBarras(codigo, 3, identificacaoValorRealOuReferencia.mod);
-            
             resultado = resultado.substr(0, 3) + DV + resultado.substr(3);
 
         }
@@ -618,7 +618,7 @@ exports.geraCodBarras = (codigo) => {
  * __Y__ | **35 a 35**  | `Dígito verificador do Bloco 3`
  * __Z__ | **47 a 47**  | `Dígito verificador do Bloco 4`
  */
-exports.validarBoleto = (codigo) => {
+exports.validarBoleto = (codigo, tipoCodigo) => {
     let retorno = {};
     codigo = codigo.replace(/[^0-9]/g, '');
 
@@ -640,7 +640,7 @@ exports.validarBoleto = (codigo) => {
         retorno.sucesso = false;
         retorno.codigoInput = codigo;
         retorno.mensagem = 'Este tipo de boleto deve possuir um código de barras 44 caracteres numéricos. Ou linha digitável de 48 caracteres numéricos.';
-    } else if (!this.validarCodigoComDV(codigo)) {
+    } else if (!this.validarCodigoComDV(codigo, tipoCodigo)) {
         retorno.sucesso = false;
         retorno.codigoInput = codigo;
         retorno.mensagem = 'A validação do dígito verificador falhou. Tem certeza que inseriu a numeração correta?';
@@ -648,8 +648,7 @@ exports.validarBoleto = (codigo) => {
         retorno.sucesso = true;
         retorno.codigoInput = codigo;
         retorno.mensagem = 'Boleto válido';
-        let tipoCodigo = this.identificarTipoCodigo(codigo);
-
+        
         switch (tipoCodigo) {
             case 'LINHA_DIGITAVEL':
                 retorno.tipoCodigoInput = 'LINHA_DIGITAVEL';

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -91,25 +91,25 @@ exports.identificarReferencia = (codigo) => {
         case '6':
             return {
                 mod: 10,
-                    efetivo: true
+                efetivo: true
             };
             break;
         case '7':
             return {
                 mod: 10,
-                    efetivo: false
+                efetivo: false
             };
             break;
         case '8':
             return {
                 mod: 11,
-                    efetivo: true
+                efetivo: true
             };
             break;
         case '9':
             return {
                 mod: 11,
-                    efetivo: false
+                efetivo: false
             };
             break;
         default:
@@ -417,7 +417,7 @@ exports.calculaDVCodBarras = (codigo, posicaoCodigo, mod) => {
     if (mod === 10) {
         return this.calculaMod10(codigo);
     } else if (mod === 11) {
-        return this.calculaMod11SemMultiplicacao10(codigo);
+        return this.calculaMod11(codigo);
     }
 }
 
@@ -471,11 +471,11 @@ exports.validarCodigoComDV = (codigo, tipoCodigo) => {
                 dv2 = parseInt(codigo.substr(23, 1));
                 dv3 = parseInt(codigo.substr(35, 1));
                 dv4 = parseInt(codigo.substr(47, 1));
-                
+
                 valid = (this.calculaMod11(bloco1) == dv1 &&
-                        this.calculaMod11(bloco2) == dv2 &&
-                        this.calculaMod11(bloco3) == dv3 &&
-                        this.calculaMod11(bloco4) == dv4)
+                    this.calculaMod11(bloco2) == dv2 &&
+                    this.calculaMod11(bloco3) == dv3 &&
+                    this.calculaMod11(bloco4) == dv4)
 
                 return valid;
             }
@@ -646,7 +646,7 @@ exports.validarBoleto = (codigo, tipoCodigo) => {
         retorno.sucesso = true;
         retorno.codigoInput = codigo;
         retorno.mensagem = 'Boleto válido';
-        
+
         switch (tipoCodigo) {
             case 'LINHA_DIGITAVEL':
                 retorno.tipoCodigoInput = 'LINHA_DIGITAVEL';
@@ -715,56 +715,98 @@ exports.calculaMod10 = (numero) => {
  * 
  * -------------
  * 
- * @return {string} soma
+ * @return {string} digito
  */
-exports.calculaMod11 = (numero) => {
-    // from: http://www.cjdinfo.com.br/publicacao-calculo-digito-verificador
-    numero = numero.replace(/\D/g, '');
+// exports.calculaMod11 = (numero) => {
+//     // from: http://www.cjdinfo.com.br/publicacao-calculo-digito-verificador
+//     numero = numero.replace(/\D/g, '');
 
-    let sequencia = [4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
-    let soma = 0;
-    let resto = 0;
+//     let sequencia = [4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+//     let soma = 0;
+//     let resto = 0;
 
-    for (let i = 0; i < 11; i++) {
-        let valor = parseInt(numero.substr(i, 1));
-        soma += valor * sequencia[i];
-    }
+//     for (let i = 0; i < 11; i++) {
+//         let valor = parseInt(numero.substr(i, 1));
+//         soma += valor * sequencia[i];
+//     }
 
-    soma *= 10;
+//     soma *= 10;
 
-    resto = soma % 11;
-    let digito = resto;
-    if (resto == 10) digito = 0;
+//     resto = soma % 11;
+//     let digito = resto;
+//     if (resto == 10) digito = 0;
 
-    return digito;
-}
+//     return digito;
+// }
 
 /** 
  * Calcula o dígito verificador de uma numeração a partir do módulo 11
  * 
  * -------------
  * 
- * @param {string} numero Numeração
+ * @param {string} x Numeração
  * 
  * -------------
  * 
- * @return {string} soma
+ * @return {string} digito
  */
-exports.calculaMod11SemMultiplicacao10 = (x) => {
-    let sequencia = [2, 3, 4, 5, 6, 7, 8, 9];
+exports.calculaMod11 = (x) => {
+    let sequencia = [4, 3, 2, 9, 8, 7, 6, 5];
     let digit = 0;
     let j = 0;
-    for (var i = x.length - 1; i >= 0; i--) {
-        if (i != 4) {
-            let mult = sequencia[j];
-            j++;
-            j %= sequencia.length;
-            digit += mult * parseInt(x.charAt(i));
-        }
+    let DAC = 0
+
+    //ITAU https://download.itau.com.br/bankline/layout_cobranca_400bytes_cnab_itau.pdf
+    for (var i = 0; i < x.length; i++) {
+        let mult = sequencia[j];
+        j++;
+        j %= sequencia.length;
+        digit += mult * parseInt(x.charAt(i));
     }
 
-    return digit % 11;
+    DAC = 11 - (digit % 11);
+
+    if (DAC == 0 || DAC == 1 || DAC == 10 || DAC == 11)
+        return 1;
+    else
+        return DAC;
 }
+
+// /** 
+//  * Calcula o dígito verificador de uma numeração a partir do módulo 11
+//  * 
+//  * -------------
+//  * 
+//  * @param {string} x Numeração
+//  * 
+//  * -------------
+//  * 
+//  * @return {string} digito
+//  */
+// exports.calculaMod11Concessionaria = (x) => {
+//     let sequencia = [4, 3, 2, 9, 8, 7, 6, 5];
+//     let digit = 0;
+//     let j = 0;
+//     let DAC = 0;
+
+//     //FEBRABAN https://cmsportal.febraban.org.br/Arquivos/documentos/PDF/Layout%20-%20C%C3%B3digo%20de%20Barras%20-%20Vers%C3%A3o%205%20-%2001_08_2016.pdf
+//     for (var i = 0; i < x.length; i++) {
+//         let mult = sequencia[j];
+//         j++;
+//         j %= sequencia.length;
+//         digit += mult * parseInt(x.charAt(i));
+//     }
+
+//     DAC = digit % 11;
+
+//     if (DAC == 1)
+//         DAC = 0;
+//     if (DAC == 10)
+//         DAC = 1;
+
+//     return DAC;
+
+// }
 
 /** 
  * Função auxiliar para remover os zeros à esquerda dos valores detectados no código inserido

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -753,7 +753,7 @@ exports.calculaMod11 = (numero) => {
  * 
  * @return {string} soma
  */
-exports.calculaMod11SemMultiplicacao10 = (numero) => {
+exports.calculaMod11SemMultiplicacao10 = (x) => {
     let sequencia = [2, 3, 4, 5, 6, 7, 8, 9];
     let digit = 0;
     let j = 0;


### PR DESCRIPTION
Utilizei a versão 4 do documento de validação de código de barras. Nesse documento, o cálculo mod11 está diferente do código atual, fazendo o dígito verificador ser calculado errado.

A principal diferença entre os códigos parece estar em que, no final de tudo, é necessário multiplicar a soma por 10. (linha 736)

Acredito já haver uma versão 5 do documento, porém tudo parece de acordo.