### PR TITLE
Adicionar validação de data para novo fator a partir de 22/02/2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Função | Definição
 `identificarTipoBoleto(codigo: string)` | Verifica a numeração e retorna o tipo do boleto inserido. Se boleto bancário, convênio ou arrecadação. Requer numeração completa (com ou sem formatação).
 `identificarReferencia(codigo: string)` | Valida o terceiro campo da numeração inserida para definir como será calculado o Dígito Verificador. Requer numeração completa (com ou sem formatação).
 `identificarData(codigo: string, tipoCodigo: string)` | Verifica a numeração, o tipo de código inserido e o tipo de boleto e retorna a data de vencimento. Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
+`identificarDataComNovoFator2025(codigo: string, tipoCodigo: string)` | Verifica a numeração, o tipo de código inserido e o tipo de boleto e retorna a data de vencimento utilizando o cálculo com o novo fator de 2025. Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
 `identificarValorCodBarrasArrecadacao(codigo: string, tipoCodigo: string)` | Verifica a numeração e o tipo de código inserido e retorna o valor do CÓDIGO DE BARRAS do tipo Arrecadação. Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
 `identificarValor(codigo: string, tipoCodigo: string)` | Verifica a numeração, o tipo de código inserido e o tipo de boleto e retorna o valor do título. Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
 `digitosVerificadores(codigo: string, mod: int)` | Verifica a numeração e o módulo a ser utilizado (Mod 10 ou Mod 11) e retorna o DV (Dígito Verificador). Requer numeração completa (com ou sem formatação) e caracteres numéricos que representam o módulo a ser usado (valores aceitos: 10 ou 11).
@@ -54,6 +55,7 @@ Retorno #1:
     "codigoBarras": "23799336051105800974404300001247044809561686237",
     "linhaDigitavel": "23790448095616862379336011058009740430000124020",
     "vencimento": "2008-11-01T23:54:59.923Z",
+    "vencimentoComNovoFator2025": "2034-09-03T23:54:59.923Z",
     "valor": 1240.2
 }
 ```
@@ -70,7 +72,7 @@ Retorno #2:
     "tipoBoleto": "BANCO",
     "codigoBarras": "34196790600001000002220000005566385101214000",
     "linhaDigitavel": "34192220090000556638551012140003679060000100000",
-    "vencimento": "2019-05-31T23:54:59.373Z",
+    "vencimento": "2044-01-20T23:54:59.373Z",
     "valor": 1000
 }
 ```

--- a/src/boleto-utils.d.ts
+++ b/src/boleto-utils.d.ts
@@ -20,11 +20,25 @@ declare module '@mrmgomes/boleto-utils' {
      */
     function identificarReferencia(codigo: string): { mod: int; efetivo: boolean };
 
+    type ObtemFatorDataParams = { codigo: string, tipoCodigo: string}
+
+    /**
+     * Verifica e retorna o fator data do boleto.
+     * Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
+     */
+    function obtemFatorData({ codigo, tipoCodigo }: ObtemFatorDataParams): number;
+
     /**
      * Verifica a numeração, o tipo de código inserido e o tipo de boleto e retorna a data de vencimento.
      * Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
      */
     function identificarData(codigo: string, tipoCodigo: string): Date;
+
+    /**
+     * Verifica a numeração, o tipo de código inserido e o tipo de boleto após 22/02/2025 e retorna a data de vencimento.
+     * Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
+     */
+    function identificarDataApos22022025(codigo: string, tipoCodigo: string): Date;
 
     /**
      * Verifica a numeração e o tipo de código inserido e retorna o valor do CÓDIGO DE BARRAS do tipo Arrecadação.
@@ -98,6 +112,7 @@ declare module '@mrmgomes/boleto-utils' {
         codigoBarras: string;
         linhaDigitavel: string;
         vencimento: string;
+        vencimentoApos22022025: string;
         valor: number;
     }
 

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -120,6 +120,18 @@ exports.identificarReferencia = (codigo) => {
     }
 }
 
+/** 
+ * Identifica e retorna o fator data do boleto
+ * 
+ * -------------
+ * 
+ * @param {string} codigo Numeração do boleto
+ * @param {string} tipoCodigo tipo de código inserido (CODIGO_DE_BARRAS / LINHA_DIGITAVEL)
+ * 
+ * -------------
+ * 
+ * @return {number} fatorData
+ */
 exports.obtemFatorData = ({ codigo, tipoCodigo }) => {
     codigo = codigo.replace(/[^0-9]/g, '');
     const tipoBoleto = this.identificarTipoBoleto(codigo);
@@ -144,7 +156,7 @@ exports.obtemFatorData = ({ codigo, tipoCodigo }) => {
 }
 
 /** 
- * Identifica o fator da data de vencimento do boleto
+ * Identifica a data de vencimento do boleto
  * 
  * -------------
  * 
@@ -168,7 +180,7 @@ exports.identificarData = (codigo, tipoCodigo) => {
 }
 
 /** 
- * Identifica o fator da data de vencimento do boleto após 22/05/2025
+ * Identifica a data de vencimento do boleto após 22/05/2025
  * 
  * -------------
  * 

--- a/src/boleto-utils.js
+++ b/src/boleto-utils.js
@@ -181,6 +181,7 @@ exports.identificarData = (codigo, tipoCodigo) => {
 
 /** 
  * Identifica a data de vencimento do boleto após 22/05/2025
+ * O novo fator já tem seu início em 1000, logo fator 1000 representa 22/05/2025
  * 
  * -------------
  * 
@@ -191,13 +192,13 @@ exports.identificarData = (codigo, tipoCodigo) => {
  * 
  * @return {Date} dataBoleto
  */
-exports.identificarDataApos22022025 = (codigo, tipoCodigo) => {
+exports.identificarDataComNovoFator2025 = (codigo, tipoCodigo) => {
     var moment = require('moment-timezone');
 
     let fatorData = this.obtemFatorData({ codigo, tipoCodigo });
     let dataBoleto = moment.tz("2025-02-22 20:54:59.000Z", "UTC");
 
-    dataBoleto.add(Number(fatorData), 'days');
+    dataBoleto.add(Number(fatorData) - 1000, 'days');
 
     return dataBoleto.toDate();
 }
@@ -706,7 +707,7 @@ exports.validarBoleto = (codigo) => {
                 retorno.codigoBarras = this.linhaDigitavel2CodBarras(codigo);
                 retorno.linhaDigitavel = codigo;
                 retorno.vencimento = this.identificarData(codigo, 'LINHA_DIGITAVEL');
-                retorno.vencimentoApos22022025 = this.identificarDataApos22022025(codigo, 'LINHA_DIGITAVEL');
+                retorno.vencimentoComNovoFator2025 = this.identificarDataComNovoFator2025(codigo, 'LINHA_DIGITAVEL');
                 retorno.valor = this.identificarValor(codigo, 'LINHA_DIGITAVEL');
                 break;
             case 'CODIGO_DE_BARRAS':
@@ -715,7 +716,7 @@ exports.validarBoleto = (codigo) => {
                 retorno.codigoBarras = codigo;
                 retorno.linhaDigitavel = this.codBarras2LinhaDigitavel(codigo, false);
                 retorno.vencimento = this.identificarData(codigo, 'CODIGO_DE_BARRAS');
-                retorno.vencimentoApos22022025 = this.identificarDataApos22022025(codigo, 'CODIGO_DE_BARRAS');
+                retorno.vencimentoComNovoFator2025 = this.identificarDataComNovoFator2025(codigo, 'CODIGO_DE_BARRAS');
                 retorno.valor = this.identificarValor(codigo, 'CODIGO_DE_BARRAS');
                 break;
             default:

--- a/test/test.js
+++ b/test/test.js
@@ -30,8 +30,9 @@ describe('Boletos de 5 campos', function () {
                 expect(result).to.have.property('codigoBarras').to.equal('10499898100000214032006561000100040099726390');
                 expect(result).to.have.property('linhaDigitavel').to.equal('10492006506100010004200997263900989810000021403');
                 expect(result).to.have.property('vencimento');
+                expect(result).to.have.property('vencimentoComNovoFator2025');
                 assert.deepEqual(result.vencimento, new Date('2022-05-10T20:54:59.000Z'));
-                assert.deepEqual(result.vencimentoApos22022025, new Date('2049-09-25T20:54:59.000Z'));
+                assert.deepEqual(result.vencimentoComNovoFator2025, new Date("2046-12-30T20:54:59.000Z"));
             });
         });
         describe('Linha Digitável', function () {
@@ -45,8 +46,9 @@ describe('Boletos de 5 campos', function () {
                 expect(result).to.have.property('codigoBarras').to.equal('10499898100000214032006561000100040099726390');
                 expect(result).to.have.property('linhaDigitavel').to.equal('10492006506100010004200997263900989810000021403');
                 expect(result).to.have.property('vencimento');
+                expect(result).to.have.property('vencimentoComNovoFator2025');
                 assert.deepEqual(result.vencimento, new Date('2022-05-10T20:54:59.000Z'));
-                assert.deepEqual(result.vencimentoApos22022025, new Date('2049-09-25T20:54:59.000Z'));
+                assert.deepEqual(result.vencimentoComNovoFator2025, new Date("2046-12-30T20:54:59.000Z"));
             });
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -31,7 +31,7 @@ describe('Boletos de 5 campos', function () {
                 expect(result).to.have.property('linhaDigitavel').to.equal('10492006506100010004200997263900989810000021403');
                 expect(result).to.have.property('vencimento');
                 assert.deepEqual(result.vencimento, new Date('2022-05-10T20:54:59.000Z'));
-                assert.deepEqual(result.vencimentoApos22052025, new Date('2049-09-25T20:54:59.000Z'));
+                assert.deepEqual(result.vencimentoApos22022025, new Date('2049-09-25T20:54:59.000Z'));
             });
         });
         describe('Linha Digitável', function () {
@@ -46,7 +46,7 @@ describe('Boletos de 5 campos', function () {
                 expect(result).to.have.property('linhaDigitavel').to.equal('10492006506100010004200997263900989810000021403');
                 expect(result).to.have.property('vencimento');
                 assert.deepEqual(result.vencimento, new Date('2022-05-10T20:54:59.000Z'));
-                assert.deepEqual(result.vencimentoApos22052025, new Date('2049-09-25T20:54:59.000Z'));
+                assert.deepEqual(result.vencimentoApos22022025, new Date('2049-09-25T20:54:59.000Z'));
             });
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -31,7 +31,7 @@ describe('Boletos de 5 campos', function () {
                 expect(result).to.have.property('linhaDigitavel').to.equal('10492006506100010004200997263900989810000021403');
                 expect(result).to.have.property('vencimento');
                 assert.deepEqual(result.vencimento, new Date('2022-05-10T20:54:59.000Z'));
-                
+                assert.deepEqual(result.vencimentoApos22052025, new Date('2049-09-25T20:54:59.000Z'));
             });
         });
         describe('Linha Digitável', function () {
@@ -46,6 +46,7 @@ describe('Boletos de 5 campos', function () {
                 expect(result).to.have.property('linhaDigitavel').to.equal('10492006506100010004200997263900989810000021403');
                 expect(result).to.have.property('vencimento');
                 assert.deepEqual(result.vencimento, new Date('2022-05-10T20:54:59.000Z'));
+                assert.deepEqual(result.vencimentoApos22052025, new Date('2049-09-25T20:54:59.000Z'));
             });
         });
     });


### PR DESCRIPTION
Adicionei uma nova validação para o fator de data, aplicável a datas posteriores a 22/02/2025. A validação foi implementada como um retorno separado, em "vencimentoApos22022025", garantindo a retrocompatibilidade com o pacote original.