### PR TITLE
fix(types): update function name in boleto-utils type definition

### DIFF
--- a/src/boleto-utils.d.ts
+++ b/src/boleto-utils.d.ts
@@ -38,7 +38,7 @@ declare module '@mrmgomes/boleto-utils' {
      * Verifica a numeração, o tipo de código inserido e o tipo de boleto após 22/02/2025 e retorna a data de vencimento.
      * Requer numeração completa (com ou sem formatação) e tipo de código que está sendo inserido (CODIGO_DE_BARRAS ou LINHA_DIGITAVEL).
      */
-    function identificarDataApos22022025(codigo: string, tipoCodigo: string): Date;
+    function identificarDataComNovoFator2025(codigo: string, tipoCodigo: string): Date;
 
     /**
      * Verifica a numeração e o tipo de código inserido e retorna o valor do CÓDIGO DE BARRAS do tipo Arrecadação.


### PR DESCRIPTION
Update function name in src/boleto-utils.d.ts from `identificarDataApos22022025` to `identificarDataComNovoFator2025` to match the renamed implementation in  src/boleto-utils.ts.

This fixes the type definition to align with the actual function name that was  previously renamed but not updated in the type file.